### PR TITLE
Fix 'call requires API level' errors in demo app

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "29.0.2"
     defaultConfig {
         applicationId "ch.ebu.peachdemo"
-        minSdkVersion 16
+        minSdkVersion 26
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
Demo app requires Android API level 21 and 26 ([build log](https://travis-ci.com/github/jelleheemskerk/peach-collector-android/builds/219852216)).

```
  The first 3 errors (out of 41) were:
  /home/travis/build/jelleheemskerk/peach-collector-android/app/src/main/java/ch/ebu/peachdemo/MediaPlayerService.java:73: Error: Call requires API level 21 (current min is 16): android.media.session.MediaController#getTransportControls [NewApi]
              mController.getTransportControls().play();
                          ~~~~~~~~~~~~~~~~~~~~
  /home/travis/build/jelleheemskerk/peach-collector-android/app/src/main/java/ch/ebu/peachdemo/MediaPlayerService.java:73: Error: Call requires API level 21 (current min is 16): android.media.session.MediaController.TransportControls#play [NewApi]
              mController.getTransportControls().play();
                                                 ~~~~
  /home/travis/build/jelleheemskerk/peach-collector-android/app/src/main/java/ch/ebu/peachdemo/MediaPlayerService.java:75: Error: Call requires API level 21 (current min is 16): android.media.session.MediaController#getTransportControls [NewApi]
              mController.getTransportControls().pause();
                          ~~~~~~~~~~~~~~~~~~~~
```